### PR TITLE
patch runit to exit(0) instead of issuing systemcall to reboot_system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+admin/runit-2.1.2/command/*
+admin/runit-2.1.2/compile/*
+admin/runit

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y build-essential make gcc
+
+COPY build-runit.sh /
+
+CMD ["/build-runit.sh"]

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -1,0 +1,13 @@
+.PHONY: build-docker all
+
+curdir=$(shell pwd)
+
+all:
+	make build-docker
+	make build-runit
+
+build-docker:
+	docker build -t runit-builder .
+
+build-runit:
+	docker run -ti --rm -v $(curdir):/builder runit-builder

--- a/admin/build-runit.sh
+++ b/admin/build-runit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+cd /builder/runit-*
+./package/install

--- a/admin/runit-2.1.2/src/runit.c
+++ b/admin/runit-2.1.2/src/runit.c
@@ -5,6 +5,8 @@
 #include <signal.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include "runit.h"
 #include "sig.h"
 #include "strerr.h"
@@ -327,7 +329,8 @@ int main (int argc, const char * const *argv, char * const *envp) {
 #ifdef RB_HALT_SYSTEM
     strerr_warn2(INFO, "system halt.", 0);
     sync();
-    reboot_system(RB_HALT_SYSTEM);
+    // Patch to play nice with docker, exit instead of "reboot_system(RB_HALT_SYSTEM);"
+    exit(0);
 #else
 #ifdef RB_HALT
     strerr_warn2(INFO, "system halt.", 0);


### PR DESCRIPTION
This patch to `runit.c` makes it `exit(0)` instead of issuing a `reboot_system`

When runit runs as a docker container, it is preferable to just exit, otherwise the container will not exit unless `killed`.

ping @olleolleolle @jensnockert